### PR TITLE
Adding aarch64 for xcaddy-bin

### DIFF
--- a/xcaddy-bin/.SRCINFO
+++ b/xcaddy-bin/.SRCINFO
@@ -1,13 +1,16 @@
 pkgbase = xcaddy-bin
 	pkgdesc = Build Caddy with plugins
 	pkgver = 0.2.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/caddyserver/xcaddy
 	arch = x86_64
+	arch = aarch64
 	license = Apache-2.0
 	provides = xcaddy
 	conflicts = xcaddy
-	source = https://github.com/caddyserver/xcaddy/releases/download/v0.2.0/xcaddy_0.2.0_linux_amd64.tar.gz
-	sha256sums = 413d79636ea07f05e52ea26976e5224df47eff2634555b47f1cb867fba35dac6
+	source_x86_64 = https://github.com/caddyserver/xcaddy/releases/download/v0.2.0/xcaddy_0.2.0_linux_amd64.tar.gz
+	sha256sums_x86_64 = 413d79636ea07f05e52ea26976e5224df47eff2634555b47f1cb867fba35dac6
+	source_aarch64 = https://github.com/caddyserver/xcaddy/releases/download/v0.2.0/xcaddy_0.2.0_linux_arm64.tar.gz
+	sha256sums_aarch64 = a63211f96a0618252920b8622a51404dd406c659e64d407cb7bd96de6cb1eea7
 
 pkgname = xcaddy-bin

--- a/xcaddy-bin/PKGBUILD
+++ b/xcaddy-bin/PKGBUILD
@@ -1,18 +1,24 @@
 # Maintainer: Nicolas Stalder <n+archlinux@stalder.io>
 pkgname=xcaddy-bin
 pkgver=0.2.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Build Caddy with plugins"
-arch=('x86_64')
+arch=('x86_64' 'aarch64')
 url="https://github.com/caddyserver/xcaddy"
 license=('Apache-2.0')
 provides=('xcaddy')
 conflicts=('xcaddy')
-source=(
+source_x86_64=(
   "https://github.com/caddyserver/xcaddy/releases/download/v${pkgver}/xcaddy_${pkgver}_linux_amd64.tar.gz"
 )
-sha256sums=(
+source_aarch64=(
+  "https://github.com/caddyserver/xcaddy/releases/download/v${pkgver}/xcaddy_${pkgver}_linux_arm64.tar.gz"
+)
+sha256sums_x86_64=(
   '413d79636ea07f05e52ea26976e5224df47eff2634555b47f1cb867fba35dac6'
+)
+sha256sums_aarch64=(
+  'a63211f96a0618252920b8622a51404dd406c659e64d407cb7bd96de6cb1eea7'
 )
 
 package() {


### PR DESCRIPTION
As requested [on the AUR](https://aur.archlinux.org/packages/xcaddy-bin/#comment-848984).