### PR TITLE
caddy-cloudflare: remove dependency on systemd-networkd-wait-online.service

### DIFF
--- a/caddy-cloudflare/caddy.service
+++ b/caddy-cloudflare/caddy.service
@@ -2,7 +2,7 @@
 Description=Caddy webserver
 Documentation=https://caddyserver.com/docs/
 After=network-online.target
-Wants=network-online.target systemd-networkd-wait-online.service
+Wants=network-online.target
 StartLimitIntervalSec=14400
 StartLimitBurst=10
 


### PR DESCRIPTION
This service is only for if you're using systemd-networkd; if you are using something else (e.g. NetworkManager) then it introduces a 2 minute delay to network-online.target while networkd times out (since it has no managed interfaces).

This matches the official Arch caddy package, see https://gitlab.archlinux.org/archlinux/packaging/packages/caddy/-/blob/main/caddy.service?ref_type=heads